### PR TITLE
Renaming things

### DIFF
--- a/packet_queue/api_server.py
+++ b/packet_queue/api_server.py
@@ -29,14 +29,14 @@ from . import command
 from . import simulation
 
 
-def CreateSite(params, pipes):
+def create_site(params, pipes):
   root = resource.Resource()
   root.putChild("pipes", PipeResource(params))
   root.putChild("bytes", MeterResource(pipes))
   return server.Site(root)
 
 
-def ParsePipeParams(args, types=None):
+def parse_pipe_params(args, types=None):
   """Ensure pipe parameter args are of correct type.
 
   Args:
@@ -95,7 +95,7 @@ class PipeResource(resource.Resource):
     content = request.content.read()  # request BODY
 
     try:
-      args = ParsePipeParams(json.loads(content), self.param_types)
+      args = parse_pipe_params(json.loads(content), self.param_types)
     except (ValueError, TypeError):
       request.setResponseCode(400)
       return json.dumps({"error": "Malformed parameter value", "request": content})
@@ -120,16 +120,16 @@ class MeterResource(resource.Resource):
 
   def render_GET(self, request):
     response = {
-        "up_bytes_attempted": self.pipes.Up.bytes_attempted,
-        "up_bytes_delivered": self.pipes.Up.bytes_delivered,
-        "down_bytes_attempted": self.pipes.Down.bytes_attempted,
-        "down_bytes_delivered": self.pipes.Down.bytes_delivered,
+        "up_bytes_attempted": self.pipes.up.bytes_attempted,
+        "up_bytes_delivered": self.pipes.up.bytes_delivered,
+        "down_bytes_attempted": self.pipes.down.bytes_attempted,
+        "down_bytes_delivered": self.pipes.down.bytes_delivered,
     }
 
     request.setHeader("Content-Type", "application/json")
     return json.dumps(response)
 
 
-def Configure():
-  params, pipes, args = command.Configure(rest_server=True)
-  reactor.listenTCP(args.rest_api_port, CreateSite(params, pipes))
+def configure():
+  params, pipes, args = command.configure(rest_server=True)
+  reactor.listenTCP(args.rest_api_port, create_site(params, pipes))

--- a/packet_queue/command.py
+++ b/packet_queue/command.py
@@ -19,7 +19,7 @@ from . import simulation
 from . import udp_proxy
 
 
-def Configure(rest_server=False):
+def configure(rest_server=False):
   """Core startup routine.
 
   Args:
@@ -59,7 +59,7 @@ def Configure(rest_server=False):
 
   if args.level == 'kernel':
     import nfqueue # Makes imports that only work on Linux.
-    nfqueue.Configure(args.transport, args.port, pipes, args.interface)
+    nfqueue.configure(args.transport, args.port, pipes, args.interface)
   else:
     if args.transport == 'tcp':
       print 'Can\'t proxy TCP packets at the user level :('
@@ -67,6 +67,6 @@ def Configure(rest_server=False):
     if not args.proxy_port:
       print '--proxy_port is required'
       sys.exit(1)
-    udp_proxy.Configure(args.port, args.proxy_port, pipes)
+    udp_proxy.configure(args.port, args.proxy_port, pipes)
 
   return params, pipes, args

--- a/packet_queue/interactive.py
+++ b/packet_queue/interactive.py
@@ -58,22 +58,22 @@ class MeterProxy(object):
     reactor.callFromThread(self._atomic_reset)
 
   def _atomic_reset(self):
-    self.pipes.Up.ResetMeter()
-    self.pipes.Down.ResetMeter()
+    self.pipes.up.reset_meter()
+    self.pipes.down.reset_meter()
 
   def __repr__(self):
     return '\n'.join([
       'up:',
-      '  attempted: {}'.format(self.pipes.Up.bytes_attempted),
-      '  delivered: {}'.format(self.pipes.Up.bytes_delivered),
+      '  attempted: {}'.format(self.pipes.up.bytes_attempted),
+      '  delivered: {}'.format(self.pipes.up.bytes_delivered),
       'down:',
-      '  attempted: {}'.format(self.pipes.Down.bytes_attempted),
-      '  delivered: {}'.format(self.pipes.Down.bytes_delivered),
+      '  attempted: {}'.format(self.pipes.down.bytes_attempted),
+      '  delivered: {}'.format(self.pipes.down.bytes_delivered),
     ])
 
 
-def Main():
-  params, pipes, _ = command.Configure()
+def main():
+  params, pipes, _ = command.configure()
   shell = embed.InteractiveShellEmbed()
   shell.confirm_exit = False
 

--- a/packet_queue/simulation.py
+++ b/packet_queue/simulation.py
@@ -19,8 +19,8 @@ from twisted.internet import reactor
 class PipePair(object):
   """Holds two Pipe instances sharing a parameter dictionary."""
   def __init__(self, params):
-    self.Up = Pipe(params)
-    self.Down = Pipe(params)
+    self.up = Pipe(params)
+    self.down = Pipe(params)
 
 
 class Pipe(object):
@@ -44,16 +44,16 @@ class Pipe(object):
   def __init__(self, params):
     self.params = params
     self.size = 0
-    self.ResetMeter()
+    self.reset_meter()
 
-  def ResetMeter(self):
+  def reset_meter(self):
     # If packets are dropped, they are counted as attempted but not delivered.
     self.bytes_attempted = 0
     self.bytes_delivered = 0
 
-  def __call__(self, callback, size):
+  def attempt(self, callback, size):
     self.bytes_attempted += size
-    def deliver_packet():
+    def deliver():
       self.bytes_delivered += size
       callback()
 
@@ -81,4 +81,4 @@ class Pipe(object):
     constant_delay = self.params['delay']
 
     reactor.callLater(throttle_delay, release_buffer)
-    reactor.callLater(throttle_delay + constant_delay, deliver_packet)
+    reactor.callLater(throttle_delay + constant_delay, deliver)

--- a/packet_queue/udp_proxy.py
+++ b/packet_queue/udp_proxy.py
@@ -21,7 +21,7 @@ from twisted.internet import reactor
 OVERHEAD = 28
 
 
-def Configure(port, proxy_port, pipes):
+def configure(port, proxy_port, pipes):
   """Starts a UDP proxy server on localhost.
 
   Returns the proxy port number, which is the same as the proxy_port param
@@ -71,7 +71,7 @@ class ProxyServer(object):
     proxy_client = self._GetProxyClient(address)
     def callback():
       proxy_client.udp.Send(data, self.server_address)
-    self.pipes.Up(callback, len(data) + OVERHEAD)
+    self.pipes.up.attempt(callback, len(data) + OVERHEAD)
 
   def _GetProxyClient(self, address):
     """Gets a proxy client for a given client address.
@@ -103,4 +103,4 @@ class ProxyClient(object):
     """
     def callback():
       self.proxy_server.udp.Send(data, self.relay_address)
-    self.proxy_server.pipes.Down(callback, len(data) + OVERHEAD)
+    self.proxy_server.pipes.down.attempt(callback, len(data) + OVERHEAD)

--- a/scripts/impaired_network_clear_iptables
+++ b/scripts/impaired_network_clear_iptables
@@ -16,4 +16,4 @@
 
 from packet_queue import nfqueue
 
-nfqueue.RemoveAll()
+nfqueue.remove_all()

--- a/scripts/impaired_network_server
+++ b/scripts/impaired_network_server
@@ -17,5 +17,5 @@
 from twisted.internet import reactor
 from packet_queue import api_server
 
-api_server.Configure()
+api_server.configure()
 reactor.run()

--- a/scripts/impaired_network_shell
+++ b/scripts/impaired_network_shell
@@ -16,4 +16,4 @@
 
 from packet_queue import interactive
 
-interactive.Main()
+interactive.main()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -99,13 +99,13 @@ class EndToEndTest(unittest.TestCase):
 
   def run_nfqueue(self):
     pipes = simulation.PipePair(self.params)
-    nfqueue.Configure('udp', self.port, pipes, 'lo')
+    nfqueue.configure('udp', self.port, pipes, 'lo')
     reactor.callLater(0, self.set_ready)
     reactor.run()
 
   def run_proxy(self):
     pipes = simulation.PipePair(self.params)
-    proxy_port = udp_proxy.Configure(self.port, 0, pipes)
+    proxy_port = udp_proxy.configure(self.port, 0, pipes)
     self.shared.proxy_port = proxy_port
     reactor.callLater(0, self.set_ready)
     reactor.run()


### PR DESCRIPTION
- snake_case per Google Python style guide.
- `Pipe#attempt` instead of `__call__`, to make it clearer what's going on.
